### PR TITLE
Cleanup for Obisidian release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,11 @@ jobs:
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v2
               with:
-                  files: obsidian-inboxer-*.zip
+                  files: |-
+                      main.js
+                      manifest.json
+                      styles.css
+                      obsidian-inboxer-*.zip
                   name: Version ${{ env.VERSION }}
                   body: |
                       ## Inboxer v${{ env.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ data.json
 
 # Exclude macOS Finder (System Explorer) View States
 .DS_Store
+bun.lockb


### PR DESCRIPTION
chore: Add Obsidian-required files to releases

This should allow Obsidian to use the plugin directly

Also ignore bun lockfile